### PR TITLE
Forcing LF line-ending for the tomcat init script on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+roles/tomcat/files/tomcat-initscript.sh text eol=lf


### PR DESCRIPTION
Resolves '/bin/bash^M: bad interpreter: No such file or directory' during `kitchen converge` when cloned to a Windows workstation
